### PR TITLE
Add Afup channels

### DIFF
--- a/channels.yml
+++ b/channels.yml
@@ -244,3 +244,19 @@ channels:
   - name: Uber Engineering
     link: https://www.youtube.com/channel/UCQlvjgieHGgkpP_9GiVyTGw
     channelId: UCQlvjgieHGgkpP_9GiVyTGw
+
+  - name: AFUP
+    link: https://www.youtube.com/user/afupPHP
+    channelId: UCb-D560WkMEPE7dwNta_nqA
+    
+  - name: AFUP Hauts de France
+    link: https://www.youtube.com/channel/UCkMGtNcB-VeqMlQ9p2JMIKg
+    channelId: UCkMGtNcB-VeqMlQ9p2JMIKg
+    
+  - name: AFUP Aix / Marseille
+    link: https://www.youtube.com/channel/UC77cQ1izl155u6Y8daMZYiA
+    channelId: UC77cQ1izl155u6Y8daMZYiA
+    
+  - name: AFUP Rennes
+    link: https://www.youtube.com/channel/UCv1VGfqKhygjTOZkdVUWfpQ
+    channelId: UCv1VGfqKhygjTOZkdVUWfpQ


### PR DESCRIPTION
AFUP organizes conferences and meetup in France
AFUP means Association Française des Utilisateurs de PHP (French Association of PHP Users)

The talks can be in french or english
https://afup.org